### PR TITLE
Remove no longer needed CSS

### DIFF
--- a/common/forge-common.css
+++ b/common/forge-common.css
@@ -75,14 +75,6 @@
     top: 2px;
 }
 
-/* jquery ui elements color fix */
-.ui-widget-content,
-.ui-state-default a, .ui-state-default a:link,
-.ui-state-default a:visited, a.ui-button, a:link.ui-button,
-a:visited.ui-button, .ui-button {
-    color: var(--red-ui-primary-text-color);
-}
-
 /** emulate FF menu labels */
 #red-ui-header > ul > li:NOT(.disabled) > ul > li:NOT(.disabled) > ul > li:NOT(.disabled) > a:hover,
 #red-ui-header > ul > li:NOT(.disabled) > ul > li:NOT(.disabled) > a:hover {
@@ -113,9 +105,4 @@ a:visited.ui-button, .ui-button {
 }
 ::-webkit-scrollbar-thumb:hover {
     background-color: var(--red-ui-secondary-text-color-hover);
-}
-
-/* hide debug scrollbar until required */
-.red-ui-debug-content {
-    overflow:auto;
 }


### PR DESCRIPTION
These customizations are no longer needed. They were added to Node-RED in the following commits:

- jQuery - [node-red/node-red@`d66def5` (#3692)](https://github.com/node-red/node-red/pull/3692/commits/d66def5530346b5ed38e57bf69cece29e00a6a6e)
- `overflow-y: auto` - [node-red/node-red@`f454c29` (#3808)](https://github.com/node-red/node-red/pull/3808/commits/f454c29b8c37942175ff0f764facf5249a00b9cd)